### PR TITLE
Added no email feature to registration page

### DIFF
--- a/GlobalBehaviorandComponents/registration.py
+++ b/GlobalBehaviorandComponents/registration.py
@@ -91,13 +91,26 @@ def gbac_registration_completion():
     okta_admin = OktaAdmin(session[SESSION_INSTANCE_SETTINGS_KEY])
     user_create_response = okta_admin.create_user(user=user_data, activate_user='false')
     logger.debug(user_create_response)
-    emailRegistration(
-        recipient={"address": request.form.get('email')},
-        token=user_create_response["id"])
+    
+    activation_link= ""
+    if request.form.get('noemail').lower() == 'true':
+        logger.debug("no email will be sent")
+        activation_link = url_for(
+        "gbac_registration_bp.gbac_registration_state_get",
+        stateToken=user_create_response["id"],
+        _external=True,
+        _scheme=session[SESSION_INSTANCE_SETTINGS_KEY]["app_scheme"])
+    else:
+        logger.debug("email sent")
+        emailRegistration(
+            recipient={"address": request.form.get('email')},
+            token=user_create_response["id"])
 
     return render_template(
         "/registration-completion.html",
         email=request.form.get('email'),
+        activationlink=activation_link,
+        noemail=request.form.get('noemail').lower(),
         templatename=get_app_vertical(),
         config=session[SESSION_INSTANCE_SETTINGS_KEY],
         _scheme=session[SESSION_INSTANCE_SETTINGS_KEY]["app_scheme"])

--- a/GlobalBehaviorandComponents/registration.py
+++ b/GlobalBehaviorandComponents/registration.py
@@ -91,15 +91,15 @@ def gbac_registration_completion():
     okta_admin = OktaAdmin(session[SESSION_INSTANCE_SETTINGS_KEY])
     user_create_response = okta_admin.create_user(user=user_data, activate_user='false')
     logger.debug(user_create_response)
-    
-    activation_link= ""
+
+    activation_link = ""
     if request.form.get('noemail').lower() == 'true':
         logger.debug("no email will be sent")
         activation_link = url_for(
-        "gbac_registration_bp.gbac_registration_state_get",
-        stateToken=user_create_response["id"],
-        _external=True,
-        _scheme=session[SESSION_INSTANCE_SETTINGS_KEY]["app_scheme"])
+            "gbac_registration_bp.gbac_registration_state_get",
+            stateToken=user_create_response["id"],
+            _external=True,
+            _scheme=session[SESSION_INSTANCE_SETTINGS_KEY]["app_scheme"])
     else:
         logger.debug("email sent")
         emailRegistration(

--- a/GlobalBehaviorandComponents/templates/components/template-registration.html
+++ b/GlobalBehaviorandComponents/templates/components/template-registration.html
@@ -12,5 +12,6 @@
         <input class="form-control rounded-pill" name="phone" id="phone" type="phone"  required="required" />
     </div>
     <button class="btn btn-primary btn-marketing btn-block rounded-pill mt-4" type="submit">Sign Up Now</button>
+    <input id="noemail" name="noemail" type="hidden" value="{{ request.args.get('noemail') }}">
 </div>
 

--- a/GlobalBehaviorandComponents/templates/registration-completion.html
+++ b/GlobalBehaviorandComponents/templates/registration-completion.html
@@ -19,7 +19,12 @@
                       <strong>Success!</strong>
                       <br>
                            An email message was sent with an activation link to <span style="color:blue;font-weight:bold">{{email}}</span>.
-                           Please click on the registration link in your email to activate your account<br>
+                            {% if noemail == 'true' %}
+                                Please click on this link to activate your account<br><br>
+                                <a href='{{activationlink}}'>{{activationlink}}</a> <br>
+                            {% else %}
+                                Please click on the registration link in your email to activate your account<br>
+                            {% endif %}
                     </div>
                     <br>
                     <br>


### PR DESCRIPTION
Added feature to registration page.

If you add ?noemail=true to /registration page, no email will be sent.

subdomain.unidemo.info/registration?noemail=true

