### PR TITLE
parameterized prompt

### DIFF
--- a/GlobalBehaviorandComponents/login.py
+++ b/GlobalBehaviorandComponents/login.py
@@ -235,7 +235,10 @@ def gbac_get_authorize_url():
     session_token = body["session_token"]
     session["state"] = str(uuid.uuid4())
 
-    oauth_authorize_url = get_oauth_authorize_url(session_token)
+    oauth_authorize_url = get_oauth_authorize_url(
+        okta_session_token=session_token, 
+        prompt="none"
+    )
 
     response = {
         "authorize_url": oauth_authorize_url
@@ -280,15 +283,17 @@ def gbac_id_tokenp():
     return json.dumps(decodedToken)
 
 
-def get_oauth_authorize_url(okta_session_token=None, prompt="none"):
+def get_oauth_authorize_url(okta_session_token=None, prompt=None):
     logger.debug("get_oauth_authorize_url()")
     okta_auth = OktaAuth(session[SESSION_INSTANCE_SETTINGS_KEY])
 
     auth_options = {
         "response_mode": "form_post",
-        "prompt": prompt,
         "scope": "openid profile email"
     }
+
+    if prompt is not None:
+        auth_options["prompt"] = prompt
 
     if "state" not in session:
         session["oidc_state"] = str(uuid.uuid4())

--- a/GlobalBehaviorandComponents/login.py
+++ b/GlobalBehaviorandComponents/login.py
@@ -235,10 +235,7 @@ def gbac_get_authorize_url():
     session_token = body["session_token"]
     session["state"] = str(uuid.uuid4())
 
-    oauth_authorize_url = get_oauth_authorize_url(
-        okta_session_token=session_token, 
-        prompt="none"
-    )
+    oauth_authorize_url = get_oauth_authorize_url(okta_session_token=session_token, prompt="none")
 
     response = {
         "authorize_url": oauth_authorize_url

--- a/GlobalBehaviorandComponents/validation.py
+++ b/GlobalBehaviorandComponents/validation.py
@@ -148,7 +148,7 @@ def get_oauth_authorize_url(okta_session_token=None, prompt=None):
 
     if prompt is not None:
         auth_options["prompt"] = prompt
-        
+
     if "state" not in session:
         session["state"] = str(uuid.uuid4())
 

--- a/GlobalBehaviorandComponents/validation.py
+++ b/GlobalBehaviorandComponents/validation.py
@@ -137,16 +137,18 @@ def gvalidation_bp_error(error_message=""):
         error_message=Markup(error_message))
 
 
-def get_oauth_authorize_url(okta_session_token=None):
+def get_oauth_authorize_url(okta_session_token=None, prompt=None):
     logger.debug("get_oauth_authorize_url()")
     okta_auth = OktaAuth(session[SESSION_INSTANCE_SETTINGS_KEY])
 
     auth_options = {
         "response_mode": "form_post",
-        "prompt": "none",
         "scope": "openid profile email"
     }
 
+    if prompt is not None:
+        auth_options["prompt"] = prompt
+        
     if "state" not in session:
         session["state"] = str(uuid.uuid4())
 


### PR DESCRIPTION
Leaves the `prompt=none` out of the request by default, but can now request a specific value if needed.