### PR TITLE
Update SMART/FHIR integration to work with UDP.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,6 +27,10 @@ APP_INFO_COLOR="#00cfd5"
 APP_WARNING_COLOR="#f4a100"
 APP_DANGER_COLOR="#e81500"
 
+#SMART/FHIR Health Insurance Endpoint
+APP_INS_FHIR_CLIENTID="0oa3gvkmdRb5n52e91d6"
+APP_INS_FHIR_API_BASE="https://mpwnxqqpp2.execute-api.us-east-1.amazonaws.com/dev"
+
 # UDP Setting
 UDP_CONFIG_URL="https://api.staging.udp.unidemo.live"
 UDP_ISSUER="https://udp-stg.oktapreview.com/oauth2/default"

--- a/_healthcare/views.py
+++ b/_healthcare/views.py
@@ -280,7 +280,7 @@ def healthcare_healthins():
     logger.debug("healthcare_healthins")
 
     # app setup
-    smartClient = _get_smart()
+    smartClient = _get_smart(request)
     accountLinked = False
     name = ""
     medications = []
@@ -339,7 +339,7 @@ def healthcare_healthins():
 @is_authenticated
 def healthcare_smartfhir_callback():
     logger.debug("healthcare_smartfhir_callback")
-    smartClient = _get_smart()
+    smartClient = _get_smart(request)
     try:
         smartClient.handle_callback(request.url)
     except Exception as e:
@@ -374,11 +374,11 @@ def _save_state(state):
     session['fhir_state'] = state
 
 
-def _get_smart():
+def _get_smart(request):
     smart_config = {
         'app_id': session[SESSION_INSTANCE_SETTINGS_KEY]["settings"]["app_ins_fhir_clientid"],
         'api_base': session[SESSION_INSTANCE_SETTINGS_KEY]["settings"]["app_ins_fhir_api_base"],
-        'redirect_uri': session[SESSION_INSTANCE_SETTINGS_KEY]["settings"]["app_ins_fhir_redirect_uri"],
+        'redirect_uri': request.url_root + "healthcare/smartfhir_callback",
         'scope': 'launch/patient patient/Patient.read patient/MedicationRequest.read patient/Claim.read'
     }
     state = session.get('fhir_state')

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -36,8 +36,7 @@ default_settings = {
         "app_deviceflow_clientsecret": os.getenv("APP_DEVICEFLOW_CLIENTSECRET", ""),
         "app_deviceflow_appname": os.getenv("APP_DEVICEFLOW_APPNAME", ""),
         "app_ins_fhir_clientid": os.getenv("APP_INS_FHIR_CLIENTID", "0oa3gvkmdRb5n52e91d6"),
-        "app_ins_fhir_api_base": os.getenv("APP_INS_FHIR_API_BASE", "https://mpwnxqqpp2.execute-api.us-east-1.amazonaws.com/dev"),
-        "app_ins_fhir_redirect_uri": os.getenv("APP_INS_FHIR_REDIRECT_URI", "")
+        "app_ins_fhir_api_base": os.getenv("APP_INS_FHIR_API_BASE", "https://mpwnxqqpp2.execute-api.us-east-1.amazonaws.com/dev")
     },
     "okta_api_token": os.getenv("OKTA_API_TOKEN", ""),
     "app_secret_key": os.getenv("SECRET_KEY", ""),

--- a/terraform/healthcare/healthcare.tf
+++ b/terraform/healthcare/healthcare.tf
@@ -140,6 +140,3 @@ output "issuer" {
 output "okta_app_oauth_id" {
   value = "${okta_app_oauth.healthcare.id}"
 }
-output "insurance_smart_app_redirect_uri" {
-  value = https://${local.app_domain}/healthcare/smartfhir_callback
-}


### PR DESCRIPTION
Removed any dependencies involving the redirect_uri that may exist with UDP apps.  I'm now calculating the SMART redirect_uri vs. expecting it to be told to me.