### PR TITLE
Fixed missing reference to the admin login screen missing 'dumps' reference

### DIFF
--- a/GlobalBehaviorandComponents/login.py
+++ b/GlobalBehaviorandComponents/login.py
@@ -41,7 +41,8 @@ def gbac_main():
         templatename=get_app_vertical(),
         appurl=appurl,
         user_info=get_userinfo(),
-        config=session[SESSION_INSTANCE_SETTINGS_KEY], state=str(uuid.uuid4()))
+        config=session[SESSION_INSTANCE_SETTINGS_KEY], state=str(uuid.uuid4()),
+        dumps=dumps)
 
 
 @gbac_bp.route("/clear_session")


### PR DESCRIPTION
fixed an issues where the "dumps" object is missing from the index / root path for the admin console since it displays the login screen vs other demos