### PR TITLE
Fixed local JWT validation

### DIFF
--- a/GlobalBehaviorandComponents/validation.py
+++ b/GlobalBehaviorandComponents/validation.py
@@ -115,15 +115,14 @@ def get_userinfo():
     logger.debug("get_userinfo()")
     user_info = None
     session[SESSION_INSTANCE_SETTINGS_KEY][GET_NEW_TOKEN_URL] = ""
-    access_token = TokenUtil.get_access_token(request.cookies)
     id_token = TokenUtil.get_id_token(request.cookies)
 
-    if TokenUtil.is_valid(access_token, session[SESSION_INSTANCE_SETTINGS_KEY]):
-        logger.debug("valid")
+    if TokenUtil.is_valid(id_token, session[SESSION_INSTANCE_SETTINGS_KEY]):
+        logger.debug("id_token Is valid")
         user_info = TokenUtil.get_claims_from_token(id_token)
         logger.debug("Global Validation user_info: {0}".format(user_info))
     else:
-        logger.debug("notvalid")
+        logger.debug("id_token Is Not valid")
         session[SESSION_INSTANCE_SETTINGS_KEY][GET_NEW_TOKEN_URL] = get_oauth_authorize_url()
     return user_info
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,7 +1,7 @@
-Flask>=1.1.2
-requests>=2.23.0
+Flask==1.1.2
+requests==2.23.0
 python-dotenv==0.13.0
 cryptography==3.3.2
-isodate>=0.5
-cachetools>=4.2.1
-okta-jwt-verifier>=0.2.3
+isodate==0.5
+cachetools==4.2.1
+okta_jwt_verifier==0.2.3


### PR DESCRIPTION
* Fixed local JWT validation due to invalid set up, including the better asyncio path
* Set fixed library call in common.txt instead of auto upgrading
* Added more detailed logging messages when locally introspecting a token