### PR TITLE
Add explicit HTTP status 200 on /healthcheck

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,7 +151,7 @@ def serve_static_html(filename):
 
 @app.route('/healthcheck')
 def healthcheck():
-    return "OK"
+    return "OK", 200
 
 
 """

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,4 +8,4 @@ class AppTest(BaseZartanTest):
         self.logger.info("test_healthcheck()")
         result = healthcheck()
         self.logger.debug("result: {0}".format(result))
-        self.assertEqual("OK", result)
+        self.assertEqual(("OK", 200), result)


### PR DESCRIPTION
Explicit return a 200, instead of default.